### PR TITLE
Potential fix for code scanning alert no. 7: Superfluous trailing arguments

### DIFF
--- a/assets/js/highlight.js
+++ b/assets/js/highlight.js
@@ -174,7 +174,7 @@
                 var a = E;
                 a.skip ? k += n : (a.rE || a.eE || (k += n), v(), a.eE && (k = n));
                 do E.cN && (y += I), E.skip || E.sL || (M += E.r), E = E.parent; while (E !== r.parent);
-                return r.starts && (r.endSameAsBegin && (r.starts.eR = r.eR), m(r.starts, "")), a.rE ? 0 : n.length;
+                return r.starts && (r.endSameAsBegin && (r.starts.eR = r.eR), m(r.starts)), a.rE ? 0 : n.length;
             }
             if (s(n, E)) throw new Error('Illegal lexeme "' + n + '" for mode "' + (E.cN || "<unnamed>") + '"');
             return k += n, n.length || 1;


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/sinakitagami.github.io/security/code-scanning/7](https://github.com/SinaKitagami/sinakitagami.github.io/security/code-scanning/7)

To fix the issue, we will remove the superfluous second argument (`""`) from the call to `m` on line 177. This ensures that the function is called with only the arguments it actually uses, improving code clarity and maintainability. No changes to the `m` function itself are required, as it already correctly handles a single parameter.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
