### PR TITLE
Potential fix for code scanning alert no. 6: Superfluous trailing arguments

### DIFF
--- a/assets/js/highlight.js
+++ b/assets/js/highlight.js
@@ -168,7 +168,7 @@
         function N(e, n) {
             if (k += e, null == n) return v(), 0;
             var t = c(n, E);
-            if (t) return t.skip ? k += n : (t.eB && (k += n), v(), t.rB || t.eB || (k = n)), m(t, n), t.rB ? 0 : n.length;
+            if (t) return t.skip ? k += n : (t.eB && (k += n), v(), t.rB || t.eB || (k = n)), m(t), t.rB ? 0 : n.length;
             var r = u(E, n);
             if (r) {
                 var a = E;


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/sinakitagami.github.io/security/code-scanning/6](https://github.com/SinaKitagami/sinakitagami.github.io/security/code-scanning/6)

To fix the issue, we need to remove the superfluous argument `n` from the call to the `m` function on line 171. This ensures that the function is called with only the arguments it is designed to handle. The change will not affect the functionality of the code, as the second argument is currently unused.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
